### PR TITLE
fix Codemirror字体渲染问题导致的，编辑时，有时光标定位不准。

### DIFF
--- a/src/Configs/appearance/$__themes_tiddlywiki_vanilla_settings_editorfontfamily.tid
+++ b/src/Configs/appearance/$__themes_tiddlywiki_vanilla_settings_editorfontfamily.tid
@@ -1,6 +1,0 @@
-created: 20190421072924643
-modified: 20200409033737038
-title: $:/themes/tiddlywiki/vanilla/settings/editorfontfamily
-type: text/vnd.tiddlywiki
-
-'Fira Code',"SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace


### PR DESCRIPTION
Fspark：CM issues看到一个类似的 ：https://github.com/codemirror/codemirror5/issues/5724

https://github.com/tiddly-gittly/Tiddlywiki-NodeJS-Github-Template/issues/49

https://github.com/tiddly-gittly/TidGi-Desktop/issues/382